### PR TITLE
Update lcd_api.py / One linefeed too many, in case the line is filled up to the last character

### DIFF
--- a/lcd/lcd_api.py
+++ b/lcd/lcd_api.py
@@ -140,7 +140,8 @@ class LcdApi:
             self.cursor_x += 1
         if self.cursor_x >= self.num_columns or char == '\n':
             self.cursor_x = 0
-            self.cursor_y += 1
+            if char == '\n':
+                self.cursor_y += 1
             if self.cursor_y >= self.num_lines:
                 self.cursor_y = 0
             self.move_to(self.cursor_x, self.cursor_y)


### PR DESCRIPTION
In case I fill the line to the last row, it skips the following line without replacement and the following line remains empty. This is independent of whether I put a \n at the end of the line or not. If I fill the display only with 19 characters instead of the 20 possible characters, the line jump to the following line works.

I walked through your code and the following change in lcd_api.py in "putchar" definition will fix this issue: